### PR TITLE
✨ add : TUTextField 추가 및 minimum Target ios 16.0 으로 수정

### DIFF
--- a/Trackus/Trackus.xcodeproj/project.pbxproj
+++ b/Trackus/Trackus.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		61F117EB2B56F2DC003761C1 /* MyProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F117EA2B56F2DC003761C1 /* MyProfileViewModel.swift */; };
 		61F117EF2B56F2FA003761C1 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F117EE2B56F2FA003761C1 /* Color+.swift */; };
 		61F117F12B56F7F6003761C1 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F117F02B56F7F6003761C1 /* CustomButton.swift */; };
+		61F1181F2B59711E003761C1 /* TUTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1181E2B59711E003761C1 /* TUTextField.swift */; };
 		82C1C6002B56E6AA00EBDAEE /* TrackusApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C1C5FF2B56E6AA00EBDAEE /* TrackusApp.swift */; };
 		82C1C6022B56E6AA00EBDAEE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C1C6012B56E6AA00EBDAEE /* ContentView.swift */; };
 		82C1C6042B56E6AA00EBDAEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82C1C6032B56E6AA00EBDAEE /* Assets.xcassets */; };
@@ -34,6 +35,7 @@
 		61F117EA2B56F2DC003761C1 /* MyProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileViewModel.swift; sourceTree = "<group>"; };
 		61F117EE2B56F2FA003761C1 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		61F117F02B56F7F6003761C1 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
+		61F1181E2B59711E003761C1 /* TUTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TUTextField.swift; sourceTree = "<group>"; };
 		82C1C5FC2B56E6AA00EBDAEE /* Trackus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Trackus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82C1C5FF2B56E6AA00EBDAEE /* TrackusApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackusApp.swift; sourceTree = "<group>"; };
 		82C1C6012B56E6AA00EBDAEE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				61F117F02B56F7F6003761C1 /* CustomButton.swift */,
+				61F1181E2B59711E003761C1 /* TUTextField.swift */,
 			);
 			path = Items;
 			sourceTree = "<group>";
@@ -311,6 +314,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61F1181F2B59711E003761C1 /* TUTextField.swift in Sources */,
 				61F117E92B56F2D1003761C1 /* ReportViewModel.swift in Sources */,
 				82C1C6022B56E6AA00EBDAEE /* ContentView.swift in Sources */,
 				61F117EB2B56F2DC003761C1 /* MyProfileViewModel.swift in Sources */,
@@ -464,6 +468,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -493,6 +498,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Trackus/Trackus/Sources/Commons/Items/TUTextField.swift
+++ b/Trackus/Trackus/Sources/Commons/Items/TUTextField.swift
@@ -1,0 +1,95 @@
+//
+//  CustomTextField.swift
+//  Trackus
+//
+//  Created by 박선구 on 1/18/24.
+//
+
+import SwiftUI
+
+// 사용 예시) TUTextField(placeholder: "닉네임", text: $myText)
+
+struct TUTextField: View {
+    var placeholder : String
+    @State var isFocused = false
+    @State var isError : Bool = false
+    @Binding var text : String
+    
+    var body: some View {
+        HStack {
+            TextField(placeholder, text: $text, prompt: Text(placeholder).foregroundColor(.gray))
+                .textInputAutocapitalization(.none)
+                .autocorrectionDisabled(true)
+                .onTapGesture {
+                    withAnimation {
+                        isFocused = true
+                        
+                        if isError == true {
+                            isError = false
+                        }
+                    }
+                }
+                .onChange(of: text) { newText in
+                    checkText(newText)
+                }
+            
+                // 키보드가 활성화 되어있는지 확인
+                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                    
+                    withAnimation {
+                        isFocused = false
+                    }
+                }
+            
+            // 텍스트 클리어 버튼
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "multiply.circle.fill")
+                        .foregroundColor(.gray)
+                }
+            }
+        }
+        .padding(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
+        .overlay(
+            RoundedRectangle(cornerRadius: 3)
+                .inset(by: 0.5)
+                .stroke(isError ? Color.red : (isFocused ? Color.white : Color.gray))
+        )
+        .foregroundStyle(.white)
+    }
+    
+    private func checkText(_ newText: String) {
+        // 글자 수 제한 20글자까지, 텍스트필드 값에 특수문자(!@#$%^&*()_+=-<>,.;'/:" 등등)와 공백이 있으면 안됨
+        
+        // 글자 수 제한 20글자
+        if newText.count > 20 {
+            isError = true
+            return
+        }
+        
+        let specialCharacters = CharacterSet(charactersIn: "!?@#$%^&*()_+=-<>,.;|/:[]{}")
+        
+        // 첫 글자에 공백이 있거나 공백이 연속되면 안됨
+        if newText.hasPrefix(" ") || newText.contains("  ") {
+            isError = true
+            return
+        }
+        
+        // 텍스트에 특수문자가 들어가면 안됨
+        if let _ = newText.rangeOfCharacter(from: specialCharacters) {
+            isError = true
+            return
+        }
+        
+        isError = false
+    }
+    
+}
+
+
+
+#Preview {
+    TUTextField(placeholder: "닉네임", text: .constant("가나다라"))
+}


### PR DESCRIPTION
## TUTextField 추가
Sources / Commons / Items 에 TUTextField 스위프트 파일을 추가했습니다.

### 기능

- 활성화 상태 시 테두리 색이 흰색, 비활성화 상태 시 회색
- 글자 수 제한 20글자, 특수문자 제한, 첫 글자에 공백이 있거나 공백이 연속되면 테두리 색이 빨강색으로
- 텍스트 clear 버튼


### 사용예시
TUTextField(placeholder: "닉네임", text: $myText)

## Minimum Deployments Target을  iOS 16.0 으로 수정
iOS 최소버전을 17.0에서 16.0으로 수정했습니다.